### PR TITLE
fix: 修复群相关事件内无法获取发送者的权限(群成员(member)/群管理(admin)/群主(owner))的问题

### DIFF
--- a/src/events/message.ts
+++ b/src/events/message.ts
@@ -141,7 +141,7 @@ export namespace MessageEvent {
             sender: {
                 user_id: payload.author?.id,
                 user_name: payload.author?.username,
-                permissions: ['normal'].concat(permissions),
+                permissions: [payload.author?.member_role || 'normal'].concat(permissions),
                 user_openid: payload.author?.user_openid || payload.author?.member_openid
             },
             timestamp: new Date(payload.timestamp).getTime() / 1000,


### PR DESCRIPTION
参考自 https://bot.q.qq.com/wiki/develop/api-v2/server-inter/message/send-receive/event.html#%E7%BE%A4%E8%81%8A%E5%85%A8%E9%87%8F%E6%B6%88%E6%81%AF 的 [事件字段].[author 对象] 中的 [member_role] 字段
已经过本地测试有效
需要再看看要不要把 'normal' 改成 'member'?